### PR TITLE
Feat: 대출 상담 등록 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.11'
+    id 'org.springframework.boot' version '2.7.1'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 }
 

--- a/src/main/java/com/loan/loan/controller/CounselController.java
+++ b/src/main/java/com/loan/loan/controller/CounselController.java
@@ -1,0 +1,25 @@
+package com.loan.loan.controller;
+
+import com.loan.loan.dto.CounselDTO;
+import com.loan.loan.dto.CounselDTO.Request;
+import com.loan.loan.dto.CounselDTO.Response;
+import com.loan.loan.dto.ResponseDTO;
+import com.loan.loan.service.CounselService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/counsels")
+public class CounselController extends AbstractController {
+
+    private final CounselService counselService;
+
+    @PostMapping
+    public ResponseDTO<Response> create(@RequestBody Request request) {
+        return ok(counselService.create(request));
+    }
+}

--- a/src/main/java/com/loan/loan/dto/CounselDTO.java
+++ b/src/main/java/com/loan/loan/dto/CounselDTO.java
@@ -1,0 +1,42 @@
+package com.loan.loan.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+public class CounselDTO {
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Getter
+    public static class Request {
+
+        private String name;
+        private String cellPhone;
+        private String email;
+        private String memo;
+        private String address;
+        private String addressDetail;
+        private String zipCode;
+    }
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Getter
+    @Setter
+    public static class Response {
+        private Long counselId;
+        private String name;
+        private String cellPhone;
+        private String email;
+        private String memo;
+        private String address;
+        private String addressDetail;
+        private String zipCode;
+        private LocalDateTime appliedAt;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+    }
+}

--- a/src/main/java/com/loan/loan/repository/CounselRepository.java
+++ b/src/main/java/com/loan/loan/repository/CounselRepository.java
@@ -1,0 +1,9 @@
+package com.loan.loan.repository;
+
+import com.loan.loan.domain.Counsel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CounselRepository extends JpaRepository<Counsel, Long> {
+}

--- a/src/main/java/com/loan/loan/service/CounselService.java
+++ b/src/main/java/com/loan/loan/service/CounselService.java
@@ -1,0 +1,10 @@
+package com.loan.loan.service;
+
+import com.loan.loan.dto.CounselDTO.Request;
+import com.loan.loan.dto.CounselDTO.Response;
+
+public interface CounselService {
+
+    Response create(Request request);
+
+}

--- a/src/main/java/com/loan/loan/service/CounselServiceImpl.java
+++ b/src/main/java/com/loan/loan/service/CounselServiceImpl.java
@@ -1,0 +1,29 @@
+package com.loan.loan.service;
+
+import com.loan.loan.domain.Counsel;
+import com.loan.loan.dto.CounselDTO.Request;
+import com.loan.loan.dto.CounselDTO.Response;
+import com.loan.loan.repository.CounselRepository;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class CounselServiceImpl implements CounselService {
+
+    private final ModelMapper modelMapper;
+    private final CounselRepository counselRepository;
+
+    @Override
+    public Response create(Request request) {
+        Counsel counsel = modelMapper.map(request, Counsel.class);
+        counsel.setAppliedAt(LocalDateTime.now());
+
+        Counsel created = counselRepository.save(counsel);
+
+        return modelMapper.map(created, Response.class);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        show_sql: true
       naming:
         physical-strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
     database-platform: org.hibernate.dialect.H2Dialect

--- a/src/test/java/com/loan/loan/service/CounselServiceTest.java
+++ b/src/test/java/com/loan/loan/service/CounselServiceTest.java
@@ -1,0 +1,58 @@
+package com.loan.loan.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.loan.loan.domain.Counsel;
+import com.loan.loan.dto.CounselDTO.Request;
+import com.loan.loan.dto.CounselDTO.Response;
+import com.loan.loan.repository.CounselRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
+
+@ExtendWith(MockitoExtension.class)
+public class CounselServiceTest {
+
+    @InjectMocks
+    CounselServiceImpl counselService;
+
+    @Mock
+    private CounselRepository counselRepository;
+
+    @Spy
+    private ModelMapper modelMapper;
+
+    @Test
+    void Should_ReturnResponseOfNewCounselEntity_When_RequestCounsel() {
+        Counsel entity = Counsel.builder()
+                .name("Member Kim")
+                .cellPhone("010-1111-2222")
+                .email("abc@def.g")
+                .memo("대출을 받고 싶어요. 연락 주세요.")
+                .zipCode("12345")
+                .address("서울특별시 어디구 모르동")
+                .addressDetail("101동 101호")
+                .build();
+
+        Request request = Request.builder()
+                .name("Member Kim")
+                .cellPhone("010-1111-2222")
+                .email("abc@def.g")
+                .memo("대출을 받고 싶어요. 연락 주세요.")
+                .zipCode("12345")
+                .address("서울특별시 어디구 모르동")
+                .addressDetail("101동 101호")
+                .build();
+
+        when(counselRepository.save(any(Counsel.class))).thenReturn(entity);
+
+        Response actual = counselService.create(request);
+        assertThat(actual.getName()).isSameAs(entity.getName());
+    }
+}


### PR DESCRIPTION
대출 상담을 등록하기 위한 기능을 구현하였다.
추가적으로 대출 상담 등록 기능에 위한 비즈니스 로직에 대한 테스트케이스를 간단하게 작성하였다.

* mysql-connector-java 와 호환성을 위한 Spring 버전 조정
* SQL query에 대한 로그를 보기 위한 application.yml 설정 수정
* '@Spy' : 실제 객체의 스파이를 생성하여 실제 객체의 메소드를 호출할 수 있게 하는 어노테이션
    - 'ObjectMapper'의 경우, 각각의 다른 오브젝트를 맵핑해주는 유틸성 오브젝트이기 때문에 따로 'Mocking' 처리를 하지 않고 실제 객체의 메소드를 호출할 수 있도록 하여 역할 자체를 수행할 수 있도록 하기 위해서 '@Spy' 어노테이션을 적용하였음.