### PR TITLE
Feat: 대출 상담 삭제 기능 구현

### DIFF
--- a/src/main/java/com/loan/loan/controller/CounselController.java
+++ b/src/main/java/com/loan/loan/controller/CounselController.java
@@ -29,4 +29,10 @@ public class CounselController extends AbstractController {
     public ResponseDTO<Response> update(@PathVariable Long counselId, @RequestBody Request request) {
         return ok(counselService.update(counselId, request));
     }
+
+    @DeleteMapping("/{counselId}")
+    public ResponseDTO<Response> delete(@PathVariable Long counselId) {
+        counselService.delete(counselId);
+        return ok();
+    }
 }

--- a/src/main/java/com/loan/loan/service/CounselService.java
+++ b/src/main/java/com/loan/loan/service/CounselService.java
@@ -10,4 +10,6 @@ public interface CounselService {
     Response get(Long counselId);
 
     Response update(Long counselId, Request request);
+
+    void delete(Long counselId);
 }

--- a/src/main/java/com/loan/loan/service/CounselServiceImpl.java
+++ b/src/main/java/com/loan/loan/service/CounselServiceImpl.java
@@ -56,5 +56,14 @@ public class CounselServiceImpl implements CounselService {
         return modelMapper.map(counsel, Response.class);
     }
 
+    @Override
+    public void delete(Long counselId) {
+        Counsel counsel = counselRepository.findById(counselId).orElseThrow(() -> {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        });
 
+        counsel.setIsDeleted(true);
+
+        counselRepository.save(counsel);
+    }
 }

--- a/src/test/java/com/loan/loan/service/CounselServiceTest.java
+++ b/src/test/java/com/loan/loan/service/CounselServiceTest.java
@@ -107,4 +107,20 @@ public class CounselServiceTest {
         assertThat(actual.getCounselId()).isSameAs(findId);
         assertThat(actual.getName()).isSameAs(request.getName());
     }
+
+    @Test
+    void Should_DeletedCounselEntity_When_RequestDeleteExistCounselInfo() {
+        Long targetId = 1L;
+
+        Counsel entity = Counsel.builder()
+                .counselId(1L)
+                .build();
+
+        when(counselRepository.save(ArgumentMatchers.any(Counsel.class))).thenReturn(entity);
+        when(counselRepository.findById(targetId)).thenReturn(Optional.ofNullable(entity));
+
+        counselService.delete(targetId);
+
+        assertThat(entity.getIsDeleted()).isSameAs(true);
+    }
 }


### PR DESCRIPTION
신청한 대출 상담을 삭제하는 기능을 구현하였다. 상담을 삭제할 때 DB에 실제로 삭제하는 것이 아닌 "isDeleted" 속성의 값만 변경하는 Soft Delete 방식으로 구현하였다.
추가적으로 삭제 기능에 대한 테스트케이스를 작성하였다.