### PR TITLE
Feat : 이용 약관 등록, 전체 조회 및 대출 신청 이용 약관 동의 기능 구현

### DIFF
--- a/src/main/java/com/loan/loan/controller/ApplicationController.java
+++ b/src/main/java/com/loan/loan/controller/ApplicationController.java
@@ -1,5 +1,7 @@
 package com.loan.loan.controller;
 
+import com.loan.loan.dto.ApplicationDTO;
+import com.loan.loan.dto.ApplicationDTO.AcceptTerms;
 import com.loan.loan.dto.ApplicationDTO.Request;
 import com.loan.loan.dto.ApplicationDTO.Response;
 import com.loan.loan.dto.ResponseDTO;
@@ -33,5 +35,10 @@ public class ApplicationController extends AbstractController {
     public ResponseDTO<Response> delete(@PathVariable Long applicationId) {
         applicationService.delete(applicationId);
         return ok();
+    }
+
+    @PostMapping("/{applicationId}/terms")
+    public ResponseDTO<Boolean> acceptTerms(@PathVariable Long applicationId, @RequestBody AcceptTerms request) {
+        return ok(applicationService.acceptTerms(applicationId, request));
     }
 }

--- a/src/main/java/com/loan/loan/controller/CounselController.java
+++ b/src/main/java/com/loan/loan/controller/CounselController.java
@@ -1,6 +1,5 @@
 package com.loan.loan.controller;
 
-import com.loan.loan.dto.CounselDTO;
 import com.loan.loan.dto.CounselDTO.Request;
 import com.loan.loan.dto.CounselDTO.Response;
 import com.loan.loan.dto.ResponseDTO;

--- a/src/main/java/com/loan/loan/controller/TermsController.java
+++ b/src/main/java/com/loan/loan/controller/TermsController.java
@@ -5,10 +5,9 @@ import com.loan.loan.dto.TermsDTO.Request;
 import com.loan.loan.dto.TermsDTO.Response;
 import com.loan.loan.service.TermsServiceImpl;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -20,5 +19,10 @@ public class TermsController extends AbstractController {
     @PostMapping
     public ResponseDTO<Response> create(@RequestBody Request request) {
         return ok(termsService.create(request));
+    }
+
+    @GetMapping
+    public ResponseDTO<List<Response>> getAll() {
+        return ok(termsService.getAll());
     }
 }

--- a/src/main/java/com/loan/loan/controller/TermsController.java
+++ b/src/main/java/com/loan/loan/controller/TermsController.java
@@ -1,0 +1,24 @@
+package com.loan.loan.controller;
+
+import com.loan.loan.dto.ResponseDTO;
+import com.loan.loan.dto.TermsDTO.Request;
+import com.loan.loan.dto.TermsDTO.Response;
+import com.loan.loan.service.TermsServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/terms")
+public class TermsController extends AbstractController {
+
+    private final TermsServiceImpl termsService;
+
+    @PostMapping
+    public ResponseDTO<Response> create(@RequestBody Request request) {
+        return ok(termsService.create(request));
+    }
+}

--- a/src/main/java/com/loan/loan/domain/AcceptTerms.java
+++ b/src/main/java/com/loan/loan/domain/AcceptTerms.java
@@ -1,0 +1,30 @@
+package com.loan.loan.domain;
+
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+
+@Entity
+@Setter
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@DynamicInsert
+@DynamicUpdate
+@Where(clause = "is_deleted=false")
+public class AcceptTerms extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long acceptTermsId;
+
+    @Column(columnDefinition = "bigint NOT NULL COMMENT '신청 ID'")
+    private Long applicationId;
+
+    @Column(columnDefinition = "bigint NOT NULL COMMENT '약관 ID'")
+    private Long termsId;
+}

--- a/src/main/java/com/loan/loan/domain/Terms.java
+++ b/src/main/java/com/loan/loan/domain/Terms.java
@@ -1,0 +1,31 @@
+package com.loan.loan.domain;
+
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+
+@Entity
+@Setter
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@DynamicInsert
+@DynamicUpdate
+@Where(clause = "is_deleted=false")
+public class Terms extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long termsId;
+
+    @Column(columnDefinition = "varchar(255) NOT NULL COMMENT '약관'")
+    private String name;
+
+    @Column(columnDefinition = "varchar(255) NOT NULL COMMENT '약관상세 URL'")
+    private String termsDetailUrl;
+}

--- a/src/main/java/com/loan/loan/dto/ApplicationDTO.java
+++ b/src/main/java/com/loan/loan/dto/ApplicationDTO.java
@@ -5,6 +5,7 @@ import lombok.*;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class ApplicationDTO implements Serializable {
 
@@ -34,5 +35,14 @@ public class ApplicationDTO implements Serializable {
         private LocalDateTime appliedAt;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
+    }
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Getter
+    @Setter
+    public static class AcceptTerms {
+        List<Long> acceptTermsIds;
     }
 }

--- a/src/main/java/com/loan/loan/dto/TermsDTO.java
+++ b/src/main/java/com/loan/loan/dto/TermsDTO.java
@@ -1,0 +1,33 @@
+package com.loan.loan.dto;
+
+import lombok.*;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public class TermsDTO implements Serializable {
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Getter
+    @Setter
+    public static class Request {
+        private String name;
+        private String termsDetailUrl;
+    }
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Getter
+    @Setter
+    public static class Response {
+        private Long termsId;
+        private String name;
+        private String termsDetailUrl;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+    }
+}

--- a/src/main/java/com/loan/loan/repository/AcceptTermsRepository.java
+++ b/src/main/java/com/loan/loan/repository/AcceptTermsRepository.java
@@ -1,0 +1,9 @@
+package com.loan.loan.repository;
+
+import com.loan.loan.domain.AcceptTerms;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AcceptTermsRepository extends JpaRepository<AcceptTerms, Long> {
+}

--- a/src/main/java/com/loan/loan/repository/TermsRepository.java
+++ b/src/main/java/com/loan/loan/repository/TermsRepository.java
@@ -1,0 +1,9 @@
+package com.loan.loan.repository;
+
+import com.loan.loan.domain.Terms;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TermsRepository extends JpaRepository<Terms, Long> {
+}

--- a/src/main/java/com/loan/loan/service/ApplicationService.java
+++ b/src/main/java/com/loan/loan/service/ApplicationService.java
@@ -1,5 +1,7 @@
 package com.loan.loan.service;
 
+import com.loan.loan.dto.ApplicationDTO;
+import com.loan.loan.dto.ApplicationDTO.AcceptTerms;
 import com.loan.loan.dto.ApplicationDTO.Request;
 import com.loan.loan.dto.ApplicationDTO.Response;
 
@@ -12,4 +14,6 @@ public interface ApplicationService {
     Response update(Long applicationId, Request request);
 
     void delete(Long applicationId);
+
+    Boolean acceptTerms(Long applicationId, AcceptTerms request);
 }

--- a/src/main/java/com/loan/loan/service/TermsService.java
+++ b/src/main/java/com/loan/loan/service/TermsService.java
@@ -1,0 +1,9 @@
+package com.loan.loan.service;
+
+import com.loan.loan.dto.TermsDTO.Request;
+import com.loan.loan.dto.TermsDTO.Response;
+
+public interface TermsService {
+
+    Response create(Request request);
+}

--- a/src/main/java/com/loan/loan/service/TermsService.java
+++ b/src/main/java/com/loan/loan/service/TermsService.java
@@ -3,7 +3,11 @@ package com.loan.loan.service;
 import com.loan.loan.dto.TermsDTO.Request;
 import com.loan.loan.dto.TermsDTO.Response;
 
+import java.util.List;
+
 public interface TermsService {
 
     Response create(Request request);
+
+    List<Response> getAll();
 }

--- a/src/main/java/com/loan/loan/service/TermsServiceImpl.java
+++ b/src/main/java/com/loan/loan/service/TermsServiceImpl.java
@@ -9,6 +9,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -22,5 +25,13 @@ public class TermsServiceImpl implements TermsService {
         Terms terms = modelMapper.map(request, Terms.class);
         Terms created = termsRepository.save(terms);
         return modelMapper.map(created, Response.class);
+    }
+
+    @Override
+    public List<Response> getAll() {
+        List<Terms> termsList = termsRepository.findAll();
+        return termsList.stream()
+                .map(t -> modelMapper.map(t, Response.class))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/loan/loan/service/TermsServiceImpl.java
+++ b/src/main/java/com/loan/loan/service/TermsServiceImpl.java
@@ -1,0 +1,26 @@
+package com.loan.loan.service;
+
+import com.loan.loan.domain.Terms;
+import com.loan.loan.dto.TermsDTO;
+import com.loan.loan.dto.TermsDTO.Response;
+import com.loan.loan.repository.TermsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class TermsServiceImpl implements TermsService {
+
+    private final TermsRepository termsRepository;
+    private final ModelMapper modelMapper;
+
+    @Override
+    public Response create(TermsDTO.Request request) {
+        Terms terms = modelMapper.map(request, Terms.class);
+        Terms created = termsRepository.save(terms);
+        return modelMapper.map(created, Response.class);
+    }
+}

--- a/src/test/java/com/loan/loan/service/ApplicationServiceTest.java
+++ b/src/test/java/com/loan/loan/service/ApplicationServiceTest.java
@@ -1,11 +1,16 @@
 package com.loan.loan.service;
 
+import com.loan.loan.domain.AcceptTerms;
 import com.loan.loan.domain.Application;
+import com.loan.loan.domain.Terms;
 import com.loan.loan.dto.ApplicationDTO;
 import com.loan.loan.dto.ApplicationDTO.Request;
 import com.loan.loan.dto.ApplicationDTO.Response;
+import com.loan.loan.exception.BaseException;
+import com.loan.loan.repository.AcceptTermsRepository;
 import com.loan.loan.repository.ApplicationRepository;
-import org.assertj.core.api.Assertions;
+import com.loan.loan.repository.TermsRepository;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -13,8 +18,12 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 
 import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,6 +38,12 @@ public class ApplicationServiceTest {
 
     @Mock
     private ApplicationRepository applicationRepository;
+
+    @Mock
+    private TermsRepository termsRepository;
+
+    @Mock
+    private AcceptTermsRepository acceptTermsRepository;
 
     @Spy
     private ModelMapper modelMapper;
@@ -108,5 +123,108 @@ public class ApplicationServiceTest {
         applicationService.delete(targetId);
 
         assertThat(entity.getIsDeleted()).isSameAs(true);
+    }
+
+    @Test
+    void Should_AddAcceptTerms_When_RequestAcceptTermsOfApplication() {
+
+        Terms entityA = Terms.builder()
+                .termsId(1L)
+                .name("약관 1")
+                .termsDetailUrl("https://sadasda.dasdsa")
+                .build();
+
+        Terms entityB = Terms.builder()
+                .termsId(2L)
+                .name("약관 2")
+                .termsDetailUrl("https://sadasda.dasdsadasda")
+                .build();
+
+        List<Long> acceptTerms = Arrays.asList(1L, 2L);
+
+        ApplicationDTO.AcceptTerms request = ApplicationDTO.AcceptTerms.builder()
+                .acceptTermsIds(acceptTerms)
+                .build();
+
+        Long findId = 1L;
+
+        when(applicationRepository.findById(findId)).thenReturn(
+                Optional.ofNullable(Application.builder().build())
+        );
+
+        when(termsRepository.findAll(Sort.by(Direction.ASC, "termsId"))).thenReturn(Arrays.asList(entityA, entityB));
+        when(acceptTermsRepository.save(any(AcceptTerms.class))).thenReturn(AcceptTerms.builder().build());
+
+        Boolean actual = applicationService.acceptTerms(findId, request);
+
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void Should_ThrowException_When_RequestNotAllAcceptTermsOfApplication() {
+
+        Terms entityA = Terms.builder()
+                .termsId(1L)
+                .name("약관 1")
+                .termsDetailUrl("https://sadasda.dasdsa")
+                .build();
+
+        Terms entityB = Terms.builder()
+                .termsId(2L)
+                .name("약관 2")
+                .termsDetailUrl("https://sadasda.dasdsadasda")
+                .build();
+
+        List<Long> acceptTerms = Arrays.asList(1L);
+
+        ApplicationDTO.AcceptTerms request = ApplicationDTO.AcceptTerms.builder()
+                .acceptTermsIds(acceptTerms)
+                .build();
+
+        Long findId = 1L;
+
+        when(applicationRepository.findById(findId)).thenReturn(
+                Optional.ofNullable(Application.builder().build())
+        );
+
+        when(termsRepository.findAll(Sort.by(Direction.ASC, "termsId"))).thenReturn(Arrays.asList(entityA, entityB));
+
+        Assertions.assertThrows(BaseException.class, () -> {
+            applicationService.acceptTerms(findId, request);
+        });
+    }
+
+    @Test
+    void Should_ThrowException_When_RequestNotExistAcceptTermsOfApplication() {
+
+        Terms entityA = Terms.builder()
+                .termsId(1L)
+                .name("약관 1")
+                .termsDetailUrl("https://sadasda.dasdsa")
+                .build();
+
+        Terms entityB = Terms.builder()
+                .termsId(2L)
+                .name("약관 2")
+                .termsDetailUrl("https://sadasda.dasdsadasda")
+                .build();
+
+        List<Long> acceptTerms = Arrays.asList(1L, 3L);
+
+        ApplicationDTO.AcceptTerms request = ApplicationDTO.AcceptTerms.builder()
+                .acceptTermsIds(acceptTerms)
+                .build();
+
+        Long findId = 1L;
+
+        when(applicationRepository.findById(findId)).thenReturn(
+                Optional.ofNullable(Application.builder().build())
+        );
+
+        when(termsRepository.findAll(Sort.by(Direction.ASC, "termsId"))).thenReturn(Arrays.asList(entityA, entityB));
+
+        Assertions.assertThrows(BaseException.class, () -> {
+            applicationService.acceptTerms(findId, request);
+        });
     }
 }

--- a/src/test/java/com/loan/loan/service/TermsServiceTest.java
+++ b/src/test/java/com/loan/loan/service/TermsServiceTest.java
@@ -1,0 +1,47 @@
+package com.loan.loan.service;
+
+import com.loan.loan.domain.Terms;
+import com.loan.loan.dto.TermsDTO.Request;
+import com.loan.loan.dto.TermsDTO.Response;
+import com.loan.loan.repository.TermsRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class TermsServiceTest {
+
+    @InjectMocks TermsServiceImpl termsService;
+
+    @Mock private TermsRepository termsRepository;
+    @Spy private ModelMapper modelMapper;
+
+    @Test
+    void Should_ReturnResponseOfNewTermsEntity_When_RequestTerms() {
+
+        Terms entity = Terms.builder()
+                .name("대출 이용 약관")
+                .termsDetailUrl("https://abc-storage.acc/sdafgdsfasd")
+                .build();
+
+        Request request = Request.builder()
+                .name("대출 이용 약관")
+                .termsDetailUrl("https://abc-storage.acc/sdafgdsfasd")
+                .build();
+
+        when(termsRepository.save(any(Terms.class))).thenReturn(entity);
+
+        Response actual = termsService.create(request);
+
+        assertThat(actual.getName()).isSameAs(entity.getName());
+        assertThat(actual.getTermsDetailUrl()).isSameAs(entity.getTermsDetailUrl());
+    }
+}

--- a/src/test/java/com/loan/loan/service/TermsServiceTest.java
+++ b/src/test/java/com/loan/loan/service/TermsServiceTest.java
@@ -12,6 +12,10 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -43,5 +47,25 @@ public class TermsServiceTest {
 
         assertThat(actual.getName()).isSameAs(entity.getName());
         assertThat(actual.getTermsDetailUrl()).isSameAs(entity.getTermsDetailUrl());
+    }
+
+    @Test
+    void Should_ReturnAllResponseOfExistTermsEntities_When_RequestTermsList() {
+        Terms entityA = Terms.builder()
+                .name("대출 이용약관 1")
+                .termsDetailUrl("https://dasdasdas/adsdasdas")
+                .build();
+
+        Terms entityB = Terms.builder()
+                .name("대출 이용약관 2")
+                .termsDetailUrl("https://dasdasdas/adsdasdas")
+                .build();
+
+        List<Terms> list = new ArrayList<>(Arrays.asList(entityA, entityB));
+        when(termsRepository.findAll()).thenReturn(list);
+
+        List<Response> actual = termsService.getAll();
+
+        assertThat(actual.size()).isSameAs(list.size());
     }
 }


### PR DESCRIPTION
이용 약관 등록과 전체 조회 기능을 구현하고, 고객의 대출 신청 시 이용 약관의 동의 내역 정보를 저장하는 로직을 구현하고,
각 기능들의 비즈니스 로직에 대한 테스트케이스를 작성하였다.